### PR TITLE
[codex] containerize static site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.astro
+.git
+.github
+.env
+.env.*
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+Dockerfile
+docker-compose.yml
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # build output
+.astro/
 dist/
 .output/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-bookworm-slim AS deps
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:20-bookworm-slim AS build
+WORKDIR /app
+ENV ASTRO_TELEMETRY_DISABLED=1
+RUN corepack enable
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+FROM nginx:1.27-alpine AS runtime
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD wget -qO- http://127.0.0.1/ >/dev/null || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  site:
+    build:
+      context: .
+    ports:
+      - "8080:80"
+    restart: unless-stopped

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,16 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /404.html;
+  }
+
+  location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|svg|ico|webp|avif|woff2?)$ {
+    try_files $uri =404;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a multi-stage Dockerfile that builds the Astro site with pnpm and serves `dist` through nginx.
- Adds a compose service exposed on host port `8080`.
- Adds nginx static-file routing and long-lived cache headers for immutable assets.
- Adds Docker ignore rules and ignores Astro generated metadata.

## Validation

- `docker compose config`
- `docker compose build`
- `docker compose up -d`
- `docker compose exec -T site wget -qO- http://127.0.0.1/`
- `docker compose down`