### PR TITLE
[codex] use Node 24 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:20-bookworm-slim AS deps
+FROM node:24-bookworm-slim AS deps
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-FROM node:20-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 WORKDIR /app
 ENV ASTRO_TELEMETRY_DISABLED=1
 RUN corepack enable

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "workbox-window": "^7.3.0"
   },
   "engines": {
-    "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+    "node": ">=24.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

- Sets the project engine requirement to Node 24+.
- Updates Docker build stages from Node 20 to Node 24.

## Validation

- `pnpm install --lockfile-only`
- `ASTRO_TELEMETRY_DISABLED=1 pnpm build`
- `docker compose config`
- `docker compose build`
- `docker compose up -d`
- `docker compose exec -T site wget -qO- http://127.0.0.1/`
- `docker compose down`