### PR TITLE
[codex] add Node 24 CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Typecheck and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+        env:
+          ASTRO_TELEMETRY_DISABLED: "1"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions CI workflow for pull requests and pushes to `main`.
- Uses Node 24 with pnpm caching.
- Installs pnpm before `actions/setup-node` configures the pnpm cache.
- Runs a frozen pnpm install, Astro typecheck, and production build.

## Validation

- Workflow syntax reviewed locally.
- The underlying commands were validated in #75 with `pnpm typecheck` and `ASTRO_TELEMETRY_DISABLED=1 pnpm build`.

## Notes

This replaces #72 with a clean main-targeted stack and uses Node 24 as requested.