### PR TITLE
[codex] update curriculum tech stack

### DIFF
--- a/src/assets/curriculum/techStack.json
+++ b/src/assets/curriculum/techStack.json
@@ -1,16 +1,26 @@
 [
-  { "title": "HTML", "from": "2021-01-01" },
-  { "title": "CSS", "from": "2021-01-01" },
-  { "title": "SQL", "from": "2021-01-01" },
-  { "title": "JavaScript", "from": "2021-05-01" },
-  { "title": "Typescript", "from": "2022-03-01" },
-  { "title": "ReactJS", "from": "2022-03-01" },
-  { "title": "Python", "from": "2022-01-01" },
-  { "title": "GraphQL", "from": "2022-04-01" },
-  { "title": "Node.js", "from": "2022-03-01" },
-  { "title": "REST API", "from": "2022-03-01" },
-  { "title": "MongoDB", "from": "2022-03-01" },
-  { "title": "Google Cloud Platform", "from": "2022-08-01" },
-  { "title": "PHP", "from": "2023-01-01" },
-  { "title": "Postgres", "from": "2023-02-01" }
+  {
+    "category": "Languages",
+    "items": ["TypeScript", "JavaScript", "Ruby", "PHP", "Python", "SQL", "HTML", "CSS"]
+  },
+  {
+    "category": "Frontend",
+    "items": ["React", "TailwindCSS", "Bootstrap", "shadcn/ui", "React Hook Form", "Zod", "TanStack Query", "TanStack Table"]
+  },
+  {
+    "category": "Backend",
+    "items": ["Ruby on Rails", "Node.js", "Express", "Laravel", "Yii Framework", "REST APIs", "GraphQL"]
+  },
+  {
+    "category": "Databases & Search",
+    "items": ["PostgreSQL", "MySQL", "MariaDB", "MongoDB", "Elasticsearch"]
+  },
+  {
+    "category": "Testing",
+    "items": ["RSpec", "Jest", "React Testing Library"]
+  },
+  {
+    "category": "Infrastructure & Tooling",
+    "items": ["Docker", "Google Cloud Platform", "Webpacker"]
+  }
 ]

--- a/src/components/atoms/ProficiencyBar.astro
+++ b/src/components/atoms/ProficiencyBar.astro
@@ -1,79 +1,23 @@
 ---
-const { stack } = Astro.props;
+type SkillGroup = {
+	category: string;
+	items: string[];
+};
+
+const { stack } = Astro.props as { stack: SkillGroup[] };
 ---
 
-{
-	stack
-		.sort((a, b) => {
-			const bDate = new Date(b.from).getTime();
-			const aDate = new Date(a.from).getTime();
-			const diff = aDate - bDate;
-			return diff;
-		})
-		.map(({ title, from }) => {
-			const years = Math.round((new Date().getTime() - new Date(from).getTime()) / 3.154e9) / 10;
-
-			const maxYears = Math.round((new Date().getTime() - new Date(stack[0].from).getTime()) / 3.154e9) / 10;
-
-			const width = Math.round((years / maxYears) * 100);
-
-			return (
-				<div class="mt-2 flex w-[90%] flex-col justify-center items-center mx-auto relative">
-					<h3 class="text-lg  mb-1 font-bold text-center">{title}</h3>
-					<div class="w-full h-7 rounded-full bg-gray-300 animation-container">
-						<div
-							class={`h-7 rounded-full progress-bar ${
-								years === maxYears ? 'rounded' : 'rounded-r'
-							} text-right pr-5 font-bold bg-primary-500 dark:bg-secondary-500 flex items-center justify-end text-white`}
-							style={{ width: `${width}%` }}
-							data-width={width}
-						>
-							<span>{years} years</span>
-						</div>
-					</div>
-				</div>
-			);
-		})
-}
-
-<style>
-	.progress-bar {
-		transition: width 1s ease-in-out;
-		width: 0;
-		border-radius: 999rem;
+<div class="mt-4 grid gap-5">
+	{
+		stack.map(({ category, items }) => (
+			<section>
+				<h3 class="text-lg font-bold text-slate-900 dark:text-slate-100">{category}</h3>
+				<ul class="mt-3 flex flex-wrap gap-2">
+					{items.map((item) => (
+						<li class="rounded-md bg-slate-200 px-3 py-2 text-sm font-semibold text-slate-900 dark:bg-slate-800 dark:text-slate-100">{item}</li>
+					))}
+				</ul>
+			</section>
+		))
 	}
-	.progress-bar span {
-		transition: opacity 1s ease-in-out;
-		opacity: 0;
-	}
-
-	.animation-container.animate .progress-bar span {
-		opacity: 1;
-	}
-
-	.animation-container.animate .progress-bar {
-		width: 100%;
-	}
-</style>
-<script>
-	const animationContainers = document.querySelectorAll('.animation-container') as NodeListOf<HTMLElement>;
-	const observer = new IntersectionObserver((entries, observer) => {
-		entries.forEach((entry) => {
-			const progressBar = entry.target.querySelector('.progress-bar') as HTMLElement;
-			const hasIntersection = entry.target.getAttribute('data-has-intersection');
-
-			if (entry.isIntersecting && !hasIntersection) {
-				const width = progressBar?.getAttribute('data-width');
-				progressBar.style.width = `${width}%`;
-				entry.target.classList.add('animate');
-				entry.target.setAttribute('data-has-intersection', 'true');
-				observer.unobserve(entry.target);
-			}
-		});
-	});
-
-	animationContainers.forEach((container) => {
-		container.setAttribute('data-has-intersection', 'false');
-		observer.observe(container);
-	});
-</script>
+</div>

--- a/src/pages/curriculum.astro
+++ b/src/pages/curriculum.astro
@@ -83,7 +83,7 @@ const navClass = 'anchor-link hover:text-primary-500  dark:hover:text-secondary-
 		</section>
 
 		<section id="tech-stack" class={`${cardClass} ${halfWidth} row-span-2`}>
-			<h2 class={titleClass}>PROFICIENCY STACK</h2>
+			<h2 class={titleClass}>TECH STACK</h2>
 			<ProficiencyBar stack={techStack} />
 		</section>
 


### PR DESCRIPTION
## Summary
- Replace the dated proficiency list with the provided grouped technology stack
- Render the curriculum tech stack as categorized skill chips instead of calculated year bars
- Rename the section heading from `PROFICIENCY STACK` to `TECH STACK`

## Validation
- `pnpm typecheck`
- `ASTRO_TELEMETRY_DISABLED=1 pnpm build`