### PR TITLE
[codex] reduce site font utility classes

### DIFF
--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -4,7 +4,7 @@
 
 @layer components {
 	.btn {
-		@apply inline-flex items-center justify-center rounded border border-transparent font-medium text-center text-base leading-snug transition py-3 px-6 shadow-lg ease-in duration-200 focus:ring-blue-500 focus:ring-offset-blue-200 focus:ring-2 focus:ring-offset-2;
+		@apply inline-flex items-center justify-center rounded border border-transparent font-medium text-center text-sm leading-snug transition py-3 px-6 shadow-lg ease-in duration-200 focus:ring-blue-500 focus:ring-offset-blue-200 focus:ring-2 focus:ring-offset-2;
 	}
 }
 

--- a/src/components/atoms/CurriculumDownload.astro
+++ b/src/components/atoms/CurriculumDownload.astro
@@ -6,7 +6,7 @@ const linkClass =
 const { downloadLinks } = Astro.props;
 ---
 
-<p class="text-sm italic gap-2 pb-6 flex flex-row">
+<p class="text-xs italic gap-2 pb-6 flex flex-row">
 	Download this curriculum:
 	{
 		downloadLinks.map((link) => (

--- a/src/components/atoms/Languages.astro
+++ b/src/components/atoms/Languages.astro
@@ -8,7 +8,7 @@ const { languages, maxLevel } = Astro.props;
 		const [first, second] = levelName.split(' - ');
 		return (
 			<div class="mt-2 flex w-[90%] flex-col justify-center items-center mx-auto relative">
-				<h3 class="text-lg mb-1 font-bold text-center">{title}</h3>
+				<h3 class="text-base mb-1 font-bold text-center">{title}</h3>
 				<div class="w-full h-7 rounded-full bg-gray-300 animation-container">
 					<div
 						class={`progress-bar h-7 rounded-full ${

--- a/src/components/atoms/Logo.astro
+++ b/src/components/atoms/Logo.astro
@@ -4,7 +4,7 @@ import Picture from '../core/Picture.astro';
 
 <div class="flex jusitfy-center items-center">
 	<img src={'default.png'} class="object-cover h-8 relative bottom-0" alt="Thomas" />
-	<span class="self-center ml-1 text lg:text-2xl font-extrabold text-gray-900 whitespace-nowrap dark:text-white">
+	<span class="self-center ml-1 text lg:text-xl font-extrabold text-gray-900 whitespace-nowrap dark:text-white">
 		Thomas Verderesi</span
 	>
 </div>

--- a/src/components/atoms/ProficiencyBar.astro
+++ b/src/components/atoms/ProficiencyBar.astro
@@ -11,10 +11,10 @@ const { stack } = Astro.props as { stack: SkillGroup[] };
 	{
 		stack.map(({ category, items }) => (
 			<section>
-				<h3 class="text-lg font-bold text-slate-900 dark:text-slate-100">{category}</h3>
+				<h3 class="text-base font-bold text-slate-900 dark:text-slate-100">{category}</h3>
 				<ul class="mt-3 flex flex-wrap gap-2">
 					{items.map((item) => (
-						<li class="rounded-md bg-slate-200 px-3 py-2 text-sm font-semibold text-slate-900 dark:bg-slate-800 dark:text-slate-100">{item}</li>
+						<li class="rounded-md bg-slate-200 px-3 py-2 text-xs font-semibold text-slate-900 dark:bg-slate-800 dark:text-slate-100">{item}</li>
 					))}
 				</ul>
 			</section>

--- a/src/components/atoms/ProjectList.astro
+++ b/src/components/atoms/ProjectList.astro
@@ -10,48 +10,48 @@ return (
 <hr class="border-slate-900 dark:border-slate-100 mt-8" />
 
 <div class="px-0 lg:px-5 flex flex-row items-center relative mt-4">
-    <h3 class="text-2xl font-bold text-slate-900 dark:text-slate-100">
+    <h3 class="text-xl font-bold text-slate-900 dark:text-slate-100">
         <div class="flex-col">
            {project.status &&  <div class="flex flex-row items-center">
-                Project {index + 1} <div class="btn bg-primary-500 dark:bg-secondary-500 text-slate-100 text-[14px] shadow-none p-1.5 py-1 ml-2 font-medium">
+                Project {index + 1} <div class="btn bg-primary-500 dark:bg-secondary-500 text-slate-100 text-xs shadow-none p-1.5 py-1 ml-2 font-medium">
                     {project.status}
                 </div>
             </div>}
-            <span class="text-2xl font-medium flex flex-col">
+            <span class="text-xl font-medium flex flex-col">
                 {project.title}
-                <span class="text-base"><em>{project.subtitle}</em></span>
+                <span class="text-sm"><em>{project.subtitle}</em></span>
             </span>
         </div>
     </h3>
 </div>
 
-<ul class="mt-2 list-inside lg:px-5 text-base lg:text-lg text-slate-900 dark:text-slate-100 transition-colors duration-200">
+<ul class="mt-2 list-inside lg:px-5 text-sm lg:text-base text-slate-900 dark:text-slate-100 transition-colors duration-200">
    {project.href &&  <li class="flex flex-row items-center hover:text-primary-500 dark:hover:text-secondary-500 font-semibold">
         <Icon name="ph:globe-bold" class="h-6 w-6 mr-1 inline" />
         <a href={project.href} target="_blank" rel="noopener noreferrer" class="">{project.href}</a>
     </li>}
     <li class="my-3">
-        <strong class="font-semibold text-lg lg:text-xl">Client</strong>
+        <strong class="font-semibold text-base lg:text-lg">Client</strong>
         <br />
         {project.client}
     </li>
     <li class="my-3">
-        <strong class="font-semibold text-lg lg:text-xl">Main goal</strong>
+        <strong class="font-semibold text-base lg:text-lg">Main goal</strong>
         <br />
         {project.mainGoal}
     </li>
     <li class="my-3">
-        <strong class="font-semibold text-lg lg:text-xl">Details and responsibilities</strong>
+        <strong class="font-semibold text-base lg:text-lg">Details and responsibilities</strong>
         <br />
         {project.details}
     </li>
     <li class="my-3">
-        <strong class="font-semibold text-lg lg:text-xl">Outcomes</strong>
+        <strong class="font-semibold text-base lg:text-lg">Outcomes</strong>
         <br />
         {project.outcomes}
     </li>
     <li class="my-3">
-        <strong class="font-semibold text-lg lg:text-xl">Technologies</strong>
+        <strong class="font-semibold text-base lg:text-lg">Technologies</strong>
         <br />
         {project.tech}
     </li>

--- a/src/components/atoms/Tags.astro
+++ b/src/components/atoms/Tags.astro
@@ -1,7 +1,7 @@
 ---
 import { getPermalink } from '~/utils/permalinks';
 
-const { tags, class: className = 'text-sm' } = Astro.props;
+const { tags, class: className = 'text-xs' } = Astro.props;
 ---
 
 {

--- a/src/components/atoms/workXP.astro
+++ b/src/components/atoms/workXP.astro
@@ -28,7 +28,7 @@ const { workExperience } = Astro.props as { workExperience: WorkExperience[] };
 			<article class={`pt-4 lg:${index === 0 ? 'pt-16' : 'pt-12'} px-0 lg:px-4 mb-0`}>
 				<div class="flex flex-col gap-2 px-0 py-5 lg:p-5 lg:pb-0">
 					<div class="flex flex-col gap-2 lg:flex-row lg:items-center">
-						<h3 class="flex flex-row items-start text-base font-semibold text-slate-900 dark:text-slate-100 lg:items-center lg:text-2xl">
+						<h3 class="flex flex-row items-start text-sm font-semibold text-slate-900 dark:text-slate-100 lg:items-center lg:text-xl">
 							<Icon name="mdi:briefcase" class="mr-1 h-6 w-6 text-primary-500 dark:text-secondary-500" />
 							{work.title}
 						</h3>
@@ -61,7 +61,7 @@ const { workExperience } = Astro.props as { workExperience: WorkExperience[] };
 					<p class="mt-4 text-justify text-slate-900 dark:text-slate-100">{work.summary}</p>
 
 					<div class="mt-5">
-						<h5 class="text-lg font-semibold text-slate-900 dark:text-slate-100">Highlights</h5>
+						<h5 class="text-base font-semibold text-slate-900 dark:text-slate-100">Highlights</h5>
 						<ul class="mt-2 list-disc list-inside text-slate-900 dark:text-slate-100">
 							{work.highlights.map((highlight) => (
 								<li class="mb-2 text-justify">{highlight}</li>
@@ -71,12 +71,12 @@ const { workExperience } = Astro.props as { workExperience: WorkExperience[] };
 
 					{work.selectedProjects && work.selectedProjects.length > 0 ? (
 						<div class="mt-5">
-							<h5 class="text-lg font-semibold text-slate-900 dark:text-slate-100">Selected Projects</h5>
+							<h5 class="text-base font-semibold text-slate-900 dark:text-slate-100">Selected Projects</h5>
 							<div class="mt-3 grid gap-3 lg:grid-cols-2">
 								{work.selectedProjects.map((project) => (
 									<article class="rounded-md border border-slate-300 p-4 dark:border-slate-700">
 										<h6 class="font-semibold text-slate-900 dark:text-slate-100">{project.title}</h6>
-										<p class="mt-2 text-sm text-slate-700 dark:text-slate-300">{project.description}</p>
+										<p class="mt-2 text-xs text-slate-700 dark:text-slate-300">{project.description}</p>
 									</article>
 								))}
 							</div>
@@ -84,10 +84,10 @@ const { workExperience } = Astro.props as { workExperience: WorkExperience[] };
 					) : null}
 
 					<div class="mt-5">
-						<h5 class="text-lg font-semibold text-slate-900 dark:text-slate-100">Technologies</h5>
+						<h5 class="text-base font-semibold text-slate-900 dark:text-slate-100">Technologies</h5>
 						<ul class="mt-3 flex flex-wrap gap-2">
 							{work.tech.map((item) => (
-								<li class="rounded-md bg-slate-200 px-3 py-2 text-sm font-semibold text-slate-900 dark:bg-slate-800 dark:text-slate-100">{item}</li>
+								<li class="rounded-md bg-slate-200 px-3 py-2 text-xs font-semibold text-slate-900 dark:bg-slate-800 dark:text-slate-100">{item}</li>
 							))}
 						</ul>
 					</div>

--- a/src/components/blog/GridItem.astro
+++ b/src/components/blog/GridItem.astro
@@ -23,7 +23,7 @@ const image = await findImage(post.image);
 				aspectRatio="16:9"
 			/>
 		</div>
-		<h3 class="mb-2 text-xl font-bold leading-snug sm:text-2xl font-heading">{post.title}</h3>
+		<h3 class="mb-2 text-lg font-bold leading-snug sm:text-xl font-heading">{post.title}</h3>
 		<p class="text-gray-700 dark:text-gray-400">{post.excerpt || post.description}</p>
 	</a>
 </article>

--- a/src/components/blog/HighlightedPosts.astro
+++ b/src/components/blog/HighlightedPosts.astro
@@ -14,11 +14,11 @@ const posts = await findPostsByIds(ids);
 
 <section class="px-4 py-16 mx-auto max-w-6xl lg:py-20">
 	<div class="flex flex-col mb-6 lg:justify-between lg:flex-row md:mb-8">
-		<h2 class="max-w-lg mb-2 text-3xl font-bold tracking-tight sm:text-4xl sm:leading-none lg:mb-5 group font-heading">
+		<h2 class="max-w-lg mb-2 text-2xl font-bold tracking-tight sm:text-3xl sm:leading-none lg:mb-5 group font-heading">
 			<span class="inline-block mb-1 sm:mb-4">Find out more content<br class="hidden md:block" /> in our Blog</span>
 		</h2>
 
-		<p class="text-gray-700 dark:text-slate-400 lg:text-sm lg:max-w-md">
+		<p class="text-gray-700 dark:text-slate-400 lg:text-xs lg:max-w-md">
 			The blog will be used to display AstroWind documentation. Each new article will be an important step that you will
 			need to know to be an expert in creating a website using Astro + Tailwind CSS The blog does not exist yet, but
 			very soon. Astro is a very interesting technology. Thanks.

--- a/src/components/blog/HomeGridItem.astro
+++ b/src/components/blog/HomeGridItem.astro
@@ -33,7 +33,7 @@ const image = await findImage(post.image);
 		}
 
 		<h3
-			class={`text-xl font-bold leading-snug sm:text-lg font-heading z-10 absolute bottom-0 left-0 right-0 ${
+			class={`text-lg font-bold leading-snug sm:text-base font-heading z-10 absolute bottom-0 left-0 right-0 ${
 				image ? 'bg-slate-100/50' : ''
 			} px-3 py-3`}
 		>

--- a/src/components/blog/LatestPosts.astro
+++ b/src/components/blog/LatestPosts.astro
@@ -8,7 +8,7 @@ const posts = await findLatestPosts({ count });
 
 <section class="flex flex-col justify-center border-t border-slate-100 dark:border-slate-800">
 	<h5
-		class="text-center my-10 font-bold tracking-tight text-3xl sm:leading-none group font-heading dark:text-slate-100 text-slate-900"
+		class="text-center my-10 font-bold tracking-tight text-2xl sm:leading-none group font-heading dark:text-slate-100 text-slate-900"
 	>
 		Latest Blog Articles
 	</h5>

--- a/src/components/blog/ListItem.astro
+++ b/src/components/blog/ListItem.astro
@@ -18,7 +18,7 @@ const image = await findImage(post.image);
 >
 	<div class="col-span-3 w-[90%]">
 		<header>
-			<h2 class="text-xl sm:text-xl font-bold leading-snug mb-2 font-heading">
+			<h2 class="text-lg sm:text-lg font-bold leading-snug mb-2 font-heading">
 				<a class="hover:text-primary-600 transition ease-in duration-200" href={getPermalink(post.slug, 'post')}>
 					{post.title}
 				</a>

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -16,7 +16,7 @@ const { post, url } = Astro.props;
 				read
 			</p>
 			<h1
-				class="px-4 sm:px-6 max-w-3xl lg:max-w-4xl mx-auto text-4xl md:text-5xl font-bold leading-normal tracking-tighter mb-8 font-heading"
+				class="px-4 sm:px-6 max-w-3xl lg:max-w-4xl mx-auto text-3xl md:text-4xl font-bold leading-normal tracking-tighter mb-8 font-heading"
 			>
 				{post.title}
 			</h1>

--- a/src/components/core/ToggleMenu.astro
+++ b/src/components/core/ToggleMenu.astro
@@ -4,7 +4,7 @@ import { Icon } from 'astro-icon/components';
 const {
 	label = 'Toggle Menu',
 	class:
-		className = 'ml-1.5 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center transition',
+		className = 'ml-1.5 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-xs p-2.5 inline-flex items-center transition',
 	iconClass = 'w-6 h-6',
 	iconName = 'tabler:menu',
 } = Astro.props;

--- a/src/components/core/ToggleTheme.astro
+++ b/src/components/core/ToggleTheme.astro
@@ -6,7 +6,7 @@ const { label = 'Toggle between Dark and Light mode', iconClass = 'w-6 h-6', ico
 
 <button
 	type="button"
-	class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center"
+	class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-xs p-2.5 inline-flex items-center"
 	aria-label={label}
 	data-aw-toggle-color-scheme
 >

--- a/src/components/widgets/Error404.astro
+++ b/src/components/widgets/Error404.astro
@@ -9,8 +9,8 @@ import { getHomePermalink } from '~/utils/permalinks';
 				<span class="sr-only">Error</span>
 				<span class="bg-clip-text text-transparent bg-gradient-to-r from-primary-500 to-secondary-500">404</span>
 			</h2>
-			<p class="text-3xl font-semibold md:text-3xl">Sorry, we couldn't find this page.</p>
-			<p class="mt-4 mb-8 text-lg text-gray-600 dark:text-slate-400">
+			<p class="text-2xl font-semibold md:text-2xl">Sorry, we couldn't find this page.</p>
+			<p class="mt-4 mb-8 text-base text-gray-600 dark:text-slate-400">
 				But dont worry, you can find plenty of other things on our homepage.
 			</p>
 			<a

--- a/src/components/widgets/Footer.astro
+++ b/src/components/widgets/Footer.astro
@@ -6,11 +6,11 @@ import Logo from '../atoms/Logo.astro';
 
 <footer class="border-t border-gray-200 dark:border-slate-800 p-10">
 	<div class="flex flex-col lg:flex-row justify-center items-center">
-		<a class="inline-block font-bold text-xl" href={getHomePermalink()}><Logo /></a>
+		<a class="inline-block font-bold text-lg" href={getHomePermalink()}><Logo /></a>
 		<ul class="flex mb-4 md:order-1 -ml-2 md:ml-4 md:mb-0">
 			<li>
 				<a
-					class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center"
+					class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-xs p-2.5 inline-flex items-center"
 					aria-label="Twitter"
 					href="https://twitter.com/tverderesi_dev"
 					target="_blank"
@@ -22,7 +22,7 @@ import Logo from '../atoms/Logo.astro';
 
 			<li>
 				<a
-					class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center"
+					class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-xs p-2.5 inline-flex items-center"
 					aria-label="Github"
 					href="https://github.com/tverderesi"
 					target="_blank"
@@ -33,7 +33,7 @@ import Logo from '../atoms/Logo.astro';
 			</li>
 			<li>
 				<a
-					class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center"
+					class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-xs p-2.5 inline-flex items-center"
 					aria-label="email"
 					href="mailto:tverderesi@gmail.com"
 					target="_blank"
@@ -44,7 +44,7 @@ import Logo from '../atoms/Logo.astro';
 			</li>
 		</ul>
 	</div>
-	<div class="text-sm text-center pt-3 w-full flex flex-row flex-wrap items-center justify-center">
+	<div class="text-xs text-center pt-3 w-full flex flex-row flex-wrap items-center justify-center">
 		Schedule Calendly meeting
 		<ul class="inline-flex gap-3 ml-3">
 			<li>
@@ -60,7 +60,7 @@ import Logo from '../atoms/Logo.astro';
 		</ul>
 	</div>
 
-	<div class="text-sm text-gray-700 mr-4 dark:text-slate-400 pt-3 text-center w-full">
+	<div class="text-xs text-gray-700 mr-4 dark:text-slate-400 pt-3 text-center w-full">
 		<a class="text-blue-600 hover:underline dark:text-gray-200" aria-label="Github" href="https://github.com/onwidget/astrowind"> Astrowind</a> Template
 		by
 		<a class="text-blue-600 hover:underline dark:text-gray-200" href="https://onwidget.com/"> onWidget</a> · All rights reserved.

--- a/src/components/widgets/GitHubProjects.astro
+++ b/src/components/widgets/GitHubProjects.astro
@@ -3,7 +3,7 @@ const githubUrl = 'https://github.com/tverderesi';
 ---
 
 <section class="mx-auto w-3/4 py-10 text-center">
-	<h2 class="text-3xl font-semibold text-slate-900 dark:text-slate-100">GitHub</h2>
+	<h2 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">GitHub</h2>
 	<p class="mx-auto mt-4 max-w-xl text-slate-700 dark:text-slate-300">
 		Explore my open-source work, experiments, and recent projects on GitHub.
 	</p>

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -19,7 +19,7 @@ import { getPermalink, getBlogPermalink, getHomePermalink } from '~/utils/permal
 			</div>
 		</div>
 		<nav class="items-center w-full md:w-auto hidden md:flex text-slate-900 dark:text-slate-200 h-screen md:h-auto" aria-label="Main navigation">
-			<ul class="flex flex-col pt-8 md:pt-0 md:flex-row md:self-center w-full md:w-auto text-lg md:text-base font-semibold">
+			<ul class="flex flex-col pt-8 md:pt-0 md:flex-row md:self-center w-full md:w-auto text-base md:text-sm font-semibold">
 				<li class="px-4 flex flex-row">
 					<a class="hover:text-primary-400 dark:hover:text-primary-400 flex pl-1 py-3 transition duration-150 ease-in-out" href={'/'}
 						><Icon name="ant-design:home-twotone" class="w-4 text-primary-400 mb-0.5" /> <span class="pl-1">Home</span>

--- a/src/components/widgets/LastestGitHub.astro
+++ b/src/components/widgets/LastestGitHub.astro
@@ -3,7 +3,7 @@ const githubUrl = 'https://github.com/tverderesi';
 ---
 
 <section class="flex flex-col items-center justify-center border-t border-slate-100 px-6 py-10 text-center dark:border-slate-800">
-	<h5 class="font-heading text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:leading-none">GitHub</h5>
+	<h5 class="font-heading text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:leading-none">GitHub</h5>
 	<p class="mt-4 max-w-xl text-slate-700 dark:text-slate-300">See my repositories and current experiments on GitHub.</p>
 	<a
 		href={githubUrl}

--- a/src/components/widgets/UnderConstruction.astro
+++ b/src/components/widgets/UnderConstruction.astro
@@ -15,7 +15,7 @@ import heroImage from '../../assets/images/hero.jpeg';
 	
 	/>
 
-	<h1 class="absolute z-10 text-5xl text-center font-bold leading-tighter tracking-tighter font-heading text-slate-900 dark:text-slate-100">
+	<h1 class="absolute z-10 text-4xl text-center font-bold leading-tighter tracking-tighter font-heading text-slate-900 dark:text-slate-100">
 		<span class="bg-clip-text text-transparent bg-gradient-to-r to-primary-500 from-secondary-500 wavy">(Always)</span>
 		Under
 		<span class="bg-clip-text text-transparent bg-gradient-to-r from-primary-500 to-secondary-500 wavy">Construction</span>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,7 +9,7 @@ const { meta = {} } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en" class="motion-safe:scroll-smooth font-light 2xl:text-[20px]">
+<html lang="en" class="motion-safe:scroll-smooth font-light 2xl:text-lg">
 	<head>
 		<MetaTags {...meta} />
 	</head>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -7,7 +7,7 @@ const { meta } = Astro.props;
 <Layout {meta}>
 	<section class="px-6 sm:px-6 py-12 sm:py-16 lg:py-20 mx-auto">
 		<header>
-			<h1 class="text-center text-4xl md:text-5xl font-bold leading-tighter tracking-tighter mb-8 md:mb-16 font-heading">
+			<h1 class="text-center text-3xl md:text-4xl font-bold leading-tighter tracking-tighter mb-8 md:mb-16 font-heading">
 				<slot name="title" />
 			</h1>
 		</header>

--- a/src/pages/curriculum.astro
+++ b/src/pages/curriculum.astro
@@ -24,7 +24,7 @@ import {
 	workExperience,
 } from '~/assets/curriculum/index.js';
 
-const titleClass = 'text-2xl lg:text-3xl font-bold text-center text-slate-900 dark:text-slate-100';
+const titleClass = 'text-xl lg:text-2xl font-bold text-center text-slate-900 dark:text-slate-100';
 
 const cardClass = 'p-5 border-slate-900 dark:border-slate-100 border-[1px] rounded-2xl w-full';
 const halfWidth = 'col-span-2 lg:col-span-1';
@@ -42,8 +42,8 @@ const navClass = 'anchor-link hover:text-primary-500  dark:hover:text-secondary-
 
 <Layout {meta}>
 	<section class="shadow-inner shadow-slate-600/30 p-20 bg-gradient-to-r from-primary-400 to-secondary-500 text-slate-100 wavy">
-		<h1 class="text-3xl lg:text-4xl font-bold">THOMAS B. VERDERESI</h1>
-		<p class="text-xl lg:text-2xl font-medium">FULLSTACK SOFTWARE ENGINEER</p>
+		<h1 class="text-2xl lg:text-3xl font-bold">THOMAS B. VERDERESI</h1>
+		<p class="text-lg lg:text-xl font-medium">FULLSTACK SOFTWARE ENGINEER</p>
 	</section>
 	<section class="px-5 py-10 lg:p-10 w-full grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-10">
 		<section class="lg:px-10 col-span-2">
@@ -53,7 +53,7 @@ const navClass = 'anchor-link hover:text-primary-500  dark:hover:text-secondary-
 		<section class={`${cardClass} col-span-2`}>
 			<h2 class={titleClass}>INDEX</h2>
 
-			<p class={`text-center text-lg lg:text-lg break-word font-extrabold text-slate-900 dark:text-slate-100`}>
+			<p class={`text-center text-base lg:text-base break-word font-extrabold text-slate-900 dark:text-slate-100`}>
 				| <a href="#contacts" class={navClass}> CONTACT</a>
 				| <a href="#meetings" class={navClass}> SCHEDULE A MEETING</a>
 				| <a href="#about" class={navClass}> ABOUT ME</a>


### PR DESCRIPTION
## Summary
- Reduce visible typography by editing component `text-*` utility classes directly
- Step Tailwind named sizes down one level, for example `2xl -> xl`, `xl -> lg`, `lg -> base`, `base -> sm`, and `sm -> xs`
- Keep Tailwind config unchanged

## Validation
- `pnpm typecheck`
- `ASTRO_TELEMETRY_DISABLED=1 pnpm build`