### PR TITLE
[codex] add AI-readable CV endpoints

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,7 @@
 User-agent: *
-Disallow:
+Allow: /
+Allow: /cv.json
+Allow: /resume.json
+Allow: /llms.txt
+
+Sitemap: https://tverderesi.dev/sitemap-index.xml

--- a/src/assets/curriculum/workExperience.json
+++ b/src/assets/curriculum/workExperience.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Software Engineer",
+    "title": "Mid Software Engineer",
     "company": "EBANX",
     "period": "CURRENT",
     "location": "Curitiba - PR, Brazil / Remote",
@@ -32,7 +32,7 @@
   {
     "title": "Full-stack Software Engineer II",
     "company": "Quadritech Tecnologia",
-    "period": "MAY/2023 - CURRENT",
+    "period": "MAY/2023 - JAN/2024",
     "location": "Curitiba - PR, Brazil",
     "area": "Full-stack Engineering, System Architecture, Public-sector Systems",
     "summary": "Work on specialized web systems for public-sector and regulated environments, contributing across architecture, backend, frontend, databases, design systems, documentation, and technical direction.",

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -1,0 +1,97 @@
+import { SITE } from '~/config';
+import aboutMe from '~/assets/curriculum/aboutMe.json';
+import contactInfoData from '~/assets/curriculum/contactInfo.json';
+import coursesData from '~/assets/curriculum/courses.json';
+import downloadLinksData from '~/assets/curriculum/downloadLinks.json';
+import educationData from '~/assets/curriculum/education.json';
+import languagesData from '~/assets/curriculum/languages.json';
+import strengthsData from '~/assets/curriculum/strengths.json';
+import techStackData from '~/assets/curriculum/techStack.json';
+import workExperienceData from '~/assets/curriculum/workExperience.json';
+
+export type Profile = {
+	name: string;
+	title: string;
+	location: string;
+	url: string;
+	email?: string;
+	github?: string;
+	linkedin?: string;
+	summary: string;
+};
+
+export type TechStackGroup = {
+	category: string;
+	items: string[];
+};
+
+export type SelectedProject = {
+	title: string;
+	description: string;
+	company?: string;
+};
+
+export type ExperienceItem = {
+	title: string;
+	company: string;
+	period: string;
+	location: string;
+	area?: string;
+	summary?: string;
+	highlights?: string[];
+	notes: string[];
+	selectedProjects?: SelectedProject[];
+	tech: string[];
+};
+
+export type Course = {
+	title: string;
+	place: string;
+	time: string;
+	credentialID?: string;
+	description?: string;
+};
+
+export const updatedAt = '2026-04-29';
+
+export const summary = aboutMe;
+export const strongPoints = strengthsData;
+export const techStack = techStackData as TechStackGroup[];
+export const courses = coursesData as Course[];
+export const education = educationData;
+export const languages = languagesData;
+export const downloadLinks = downloadLinksData;
+export const contactInfo = contactInfoData;
+
+const emailHref = contactInfoData.find((item) => item.href.startsWith('mailto:'))?.href;
+const githubHref = contactInfoData.find((item) => item.href.includes('github.com'))?.href;
+const linkedinHref = contactInfoData.find((item) => item.href.includes('linkedin.com'))?.href;
+
+export const profile: Profile = {
+	name: 'Thomas B. Verderesi',
+	title: 'Fullstack Software Engineer',
+	location: 'Curitiba, Parana, Brazil',
+	url: SITE.origin,
+	email: emailHref?.replace('mailto:', ''),
+	github: githubHref,
+	linkedin: linkedinHref,
+	summary: summary[0],
+};
+
+export const experience = (workExperienceData as Array<Omit<ExperienceItem, 'notes'> & { highlights?: string[] }>).map((item) => ({
+	...item,
+	notes: item.highlights ?? [],
+})) satisfies ExperienceItem[];
+
+export const projects = experience.flatMap((item) =>
+	(item.selectedProjects ?? []).map((project) => ({
+		...project,
+		company: item.company,
+	}))
+);
+
+export const address = {
+	locality: 'Curitiba',
+	region: 'PR',
+	country: 'BR',
+};

--- a/src/lib/cvPayload.ts
+++ b/src/lib/cvPayload.ts
@@ -1,0 +1,18 @@
+import { courses, experience, profile, projects, strongPoints, summary, techStack, updatedAt } from '~/data/cv';
+
+export const getCvPayload = () => ({
+	schemaVersion: '1.0',
+	type: 'ProfessionalProfile',
+	profile,
+	summary,
+	strongPoints,
+	techStack,
+	experience,
+	courses,
+	projects,
+	updatedAt,
+});
+
+export const jsonHeaders = {
+	'Content-Type': 'application/json; charset=utf-8',
+};

--- a/src/pages/curriculum.astro
+++ b/src/pages/curriculum.astro
@@ -12,17 +12,7 @@ import WorkXP from '~/components/atoms/workXP.astro';
 import Education from '~/components/atoms/Education.astro';
 import Courses from '~/components/atoms/Courses.astro';
 import Languages from '~/components/atoms/Languages.astro';
-import {
-	aboutMe,
-	contactInfo,
-	courses,
-	downloadLinks,
-	education,
-	languages,
-	strengths,
-	techStack,
-	workExperience,
-} from '~/assets/curriculum/index.js';
+import { address, contactInfo, courses, downloadLinks, education, experience, languages, profile, strongPoints, summary, techStack } from '~/data/cv';
 
 const titleClass = 'text-2xl lg:text-3xl font-bold text-center text-slate-900 dark:text-slate-100';
 
@@ -37,10 +27,28 @@ const meta = {
 
 const navClass = 'anchor-link hover:text-primary-500  dark:hover:text-secondary-500 transition-colors duration-20';
 
+const jsonLd = {
+	'@context': 'https://schema.org',
+	'@type': 'Person',
+	name: profile.name,
+	jobTitle: profile.title,
+	url: profile.url,
+	description: profile.summary,
+	sameAs: [profile.github, profile.linkedin].filter(Boolean),
+	address: {
+		'@type': 'PostalAddress',
+		addressLocality: address.locality,
+		addressRegion: address.region,
+		addressCountry: address.country,
+	},
+	knowsAbout: techStack.flatMap((group) => group.items),
+};
+
 // Smooth scrolling for anchor links
 ---
 
 <Layout {meta}>
+	<script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 	<section class="shadow-inner shadow-slate-600/30 p-20 bg-gradient-to-r from-primary-400 to-secondary-500 text-slate-100 wavy">
 		<h1 class="text-3xl lg:text-4xl font-bold">THOMAS B. VERDERESI</h1>
 		<p class="text-xl lg:text-2xl font-medium">FULLSTACK SOFTWARE ENGINEER</p>
@@ -79,7 +87,7 @@ const navClass = 'anchor-link hover:text-primary-500  dark:hover:text-secondary-
 
 		<section id="about" class={`${cardClass} ${halfWidth} row-span-1`}>
 			<h2 class={titleClass}>ABOUT ME</h2>
-			<Paragraphs paragraphs={aboutMe} />
+			<Paragraphs paragraphs={summary} />
 		</section>
 
 		<section id="tech-stack" class={`${cardClass} ${halfWidth} row-span-2`}>
@@ -90,13 +98,13 @@ const navClass = 'anchor-link hover:text-primary-500  dark:hover:text-secondary-
 		<section id="strengths" class={`${cardClass} ${halfWidth} row-span-1`}>
 			<h2 class={titleClass}>STRENGTHS & SKILLS</h2>
 			<ul class="mt-2 list-disc list-inside text-slate-900 dark:text-slate-100">
-				{strengths.map((strength) => <li class="mb-2 text-justify text-slate-900 dark:text-slate-100 ">{strength}</li>)}
+				{strongPoints.map((strength) => <li class="mb-2 text-justify text-slate-900 dark:text-slate-100 ">{strength}</li>)}
 			</ul>
 		</section>
 
 		<section id="work-xp" class={`${cardClass}  col-span-2 lg:col-span-2`}>
 			<h2 class={titleClass}>WORK EXPERIENCE</h2>
-			<WorkXP workExperience={workExperience} />
+			<WorkXP workExperience={experience} />
 		</section>
 
 		<div class={`${cardClass} ${halfWidth}`} id="education">

--- a/src/pages/cv.json.ts
+++ b/src/pages/cv.json.ts
@@ -1,0 +1,9 @@
+import type { APIRoute } from 'astro';
+import { getCvPayload, jsonHeaders } from '~/lib/cvPayload';
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+	new Response(JSON.stringify(getCvPayload(), null, 2), {
+		headers: jsonHeaders,
+	});

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,44 @@
+import type { APIRoute } from 'astro';
+import { profile, projects } from '~/data/cv';
+
+export const prerender = true;
+
+const projectLines = projects.map((project) => `- ${project.title}: ${project.description}`).join('\n');
+
+const content = `# ${profile.name}
+
+> ${profile.title} based in ${profile.location}.
+
+This site contains the public professional profile, work experience, technical stack, courses, certifications, and selected projects of ${profile.name}.
+
+## Primary resources
+
+- [Human-readable portfolio](${profile.url}/)
+- [Human-readable CV](${profile.url}/curriculum)
+- [Project listing](${profile.url}/portfolio)
+- [Structured CV JSON](${profile.url}/cv.json)
+- [Resume JSON alias](${profile.url}/resume.json)
+
+## Suggested usage
+
+Use /cv.json as the canonical source for structured professional information.
+Prefer the JSON endpoint over scraping HTML.
+Do not infer employment details, seniority, private clients, confidential projects, or NDA-sensitive information beyond what is explicitly present in the structured data.
+
+## Content categories
+
+- Professional summary
+- Work experience
+- Technical stack
+- Strong points
+- Courses and certifications
+- Selected projects
+
+${projectLines ? `## Selected public projects\n\n${projectLines}\n` : ''}`;
+
+export const GET: APIRoute = () =>
+	new Response(content, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+		},
+	});

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,8 +1,10 @@
 import type { APIRoute } from 'astro';
-import { profile, projects } from '~/data/cv';
+import { experience, profile, projects, techStack } from '~/data/cv';
 
 export const prerender = true;
 
+const technologyLines = techStack.map((group) => `- ${group.category}: ${group.items.join(', ')}`).join('\n');
+const employmentLines = experience.map((job) => `- ${job.company}: ${job.title}, ${job.period}`).join('\n');
 const projectLines = projects.map((project) => `- ${project.title}: ${project.description}`).join('\n');
 
 const content = `# ${profile.name}
@@ -33,6 +35,14 @@ Do not infer employment details, seniority, private clients, confidential projec
 - Strong points
 - Courses and certifications
 - Selected projects
+
+## Technologies
+
+${technologyLines}
+
+## Employment history
+
+${employmentLines}
 
 ${projectLines ? `## Selected public projects\n\n${projectLines}\n` : ''}`;
 

--- a/src/pages/resume.json.ts
+++ b/src/pages/resume.json.ts
@@ -1,0 +1,9 @@
+import type { APIRoute } from 'astro';
+import { getCvPayload, jsonHeaders } from '~/lib/cvPayload';
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+	new Response(JSON.stringify(getCvPayload(), null, 2), {
+		headers: jsonHeaders,
+	});


### PR DESCRIPTION
## Summary

Adds a static, machine-readable CV layer for the Astro portfolio.

- Adds a canonical `src/data/cv.ts` module sourced from the existing public curriculum data.
- Adds prerendered `/cv.json`, `/resume.json`, and `/llms.txt` endpoints.
- Updates the curriculum page to use the canonical CV module and emit Schema.org `Person` JSON-LD.
- Updates `robots.txt` to explicitly allow the new AI-readable routes and reference the generated sitemap.

## Validation

- `pnpm check`
- `ASTRO_TELEMETRY_DISABLED=1 pnpm build`
- Generated-output sanity check for valid `/cv.json`, `/resume.json` alias parity, `/llms.txt` references, and JSON-LD presence in `dist/curriculum/index.html`.

Note: `pnpm check` still reports existing Astro/TypeScript hints in unrelated files, but exits successfully.