### PR TITLE
[codex] add generated curriculum PDFs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,15 @@
   for = "/assets/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/api/curriculum/en-us.pdf"
+  [headers.values]
+    Content-Type = "application/pdf"
+    Content-Disposition = "attachment; filename=\"thomas-verderesi-curriculum-en-us.pdf\""
+
+[[headers]]
+  for = "/api/curriculum/pt-br.pdf"
+  [headers.values]
+    Content-Type = "application/pdf"
+    Content-Disposition = "attachment; filename=\"thomas-verderesi-curriculo-pt-br.pdf\""

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@iconify-json/ph": "^1.2.2",
     "@iconify-json/tabler": "^1.2.33",
     "@tailwindcss/typography": "^0.5.19",
+    "@types/pdfkit": "^0.17.6",
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "astro": "^6.1.6",
@@ -70,6 +71,7 @@
   "dependencies": {
     "@vite-pwa/astro": "^1.2.0",
     "dotenv": "^17.2.3",
+    "pdfkit": "^0.18.0",
     "slug": "^11.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
+      pdfkit:
+        specifier: ^0.18.0
+        version: 0.18.0
       slug:
         specifier: ^11.0.1
         version: 11.0.1
@@ -75,6 +78,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.19(yaml@2.8.3))
+      '@types/pdfkit':
+        specifier: ^0.17.6
+        version: 0.17.6
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.49.0
         version: 8.59.1(@typescript-eslint/parser@8.59.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -1330,6 +1336,14 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
@@ -1599,6 +1613,9 @@ packages:
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
+  '@swc/helpers@0.5.21':
+    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
   '@tailwindcss/typography@0.5.19':
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
     peerDependencies:
@@ -1657,6 +1674,9 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/pdfkit@0.17.6':
+    resolution: {integrity: sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -1929,6 +1949,13 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.24:
     resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
     engines: {node: '>=6.0.0'}
@@ -1954,6 +1981,12 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -2045,6 +2078,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2220,6 +2257,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2548,6 +2588,9 @@ packages:
 
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
@@ -2966,6 +3009,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3114,6 +3160,9 @@ packages:
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -3493,6 +3542,12 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -3547,6 +3602,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfkit@0.18.0:
+    resolution: {integrity: sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -3577,6 +3635,9 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  png-js@1.1.0:
+    resolution: {integrity: sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3823,6 +3884,9 @@ packages:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
@@ -4246,9 +4310,15 @@ packages:
     resolution: {integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==}
     engines: {node: '>=4'}
 
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -6039,6 +6109,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6270,6 +6344,10 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
 
+  '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
   '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(yaml@2.8.3))':
     dependencies:
       postcss-selector-parser: 6.0.10
@@ -6343,6 +6421,10 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/pdfkit@0.17.6':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/resolve@1.20.2': {}
 
@@ -6916,6 +6998,10 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.24: {}
 
   binary-extensions@2.3.0: {}
@@ -6938,6 +7024,14 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.28.2:
     dependencies:
@@ -7050,6 +7144,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clone@2.1.2: {}
 
   clsx@2.1.1: {}
 
@@ -7197,6 +7293,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dfa@1.2.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -7690,6 +7788,18 @@ snapshots:
   fontace@0.4.1:
     dependencies:
       fontkitten: 1.0.3
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.21
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
 
   fontkitten@1.0.3:
     dependencies:
@@ -8198,6 +8308,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  js-md5@0.8.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -8306,6 +8418,11 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@1.2.4: {}
 
@@ -8960,6 +9077,10 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@0.2.9: {}
+
+  pako@1.0.11: {}
+
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -9025,6 +9146,15 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pdfkit@0.18.0:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      fontkit: 2.0.4
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 1.1.0
+
   pend@1.2.0: {}
 
   piccolore@0.1.3: {}
@@ -9050,6 +9180,10 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  png-js@1.1.0:
+    dependencies:
+      browserify-zlib: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9336,6 +9470,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restructure@3.0.2: {}
 
   retext-latin@4.0.0:
     dependencies:
@@ -9903,7 +10039,17 @@ snapshots:
 
   unicode-match-property-value-ecmascript@2.2.1: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unified@11.0.5:
     dependencies:

--- a/src/assets/curriculum/downloadLinks.json
+++ b/src/assets/curriculum/downloadLinks.json
@@ -1,12 +1,14 @@
 [
   {
-    "href": "https://1drv.ms/b/s!Ai-_aSZmd3wI37VU5Q9anoj4v0LN5Q?e=J8883J",
+    "href": "/api/curriculum/en-us.pdf",
+    "filename": "thomas-verderesi-curriculum-en-us.pdf",
     "format": "PDF (EN-US)",
     "icon": "carbon:document-pdf",
     "ariaLabel": "Download PDF curriculum in English."
   },
   {
-    "href": "https://rnawng.bn.files.1drv.com/y4mA9gTrjJ4to7R3Sh4YE05NTt2oqbzxWtERFrmjW5m75sVD8YyOAv4_6RVGBvhHSh2f9fe2ONz7s-rRd0wgLdicUE0RWKU_-6GJI-yek-itTgYqThHGSVtl4Po-NoZZrJt4H1tmcuxRuU_hZK7NJQgUnUtq3krFnDF85rNyEL_MNcO-k6wmi9afExzk9jFWisLG8Qh3t-h-RbyEdYmkhtMiJ7xhbNck5yOHmyTPmQxDoQ?AVOverride=1",
+    "href": "/api/curriculum/pt-br.pdf",
+    "filename": "thomas-verderesi-curriculo-pt-br.pdf",
     "format": "PDF (PT-BR)",
     "icon": "carbon:document-pdf",
     "ariaLabel": "Download PDF curriculum in Portuguese."

--- a/src/components/atoms/CurriculumDownload.astro
+++ b/src/components/atoms/CurriculumDownload.astro
@@ -1,18 +1,31 @@
 ---
 import { Icon } from 'astro-icon/components';
 
+type DownloadLink = {
+	href: string;
+	filename: string;
+	format: string;
+	icon: string;
+	ariaLabel: string;
+};
+
 const linkClass =
-	'flex hover:text-primary-400 dark:hover:text-secondary-400 not-italic font-bold transition-colors duration-200 ease-in-out';
-const { downloadLinks } = Astro.props;
+	'inline-flex items-center gap-2 rounded-sm border border-slate-300 px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:border-slate-900 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 dark:border-slate-600 dark:text-yellow-50 dark:hover:border-yellow-50 dark:hover:bg-slate-900 dark:focus-visible:outline-yellow-50';
+const { downloadLinks } = Astro.props as { downloadLinks: DownloadLink[] };
 ---
 
-<p class="text-sm italic gap-2 pb-6 flex flex-row">
-	Download this curriculum:
-	{
-		downloadLinks.map((link) => (
-			<a href={link.href} download class={linkClass} aria-label={link.ariaLabel}>
-				<Icon name={link.icon} class="h-4 w-4 mr-1" /> {link.format}
-			</a>
-		))
-	}
-</p>
+<section
+	aria-labelledby="download-curriculum"
+	class="border border-slate-300 bg-white p-4 text-slate-900 dark:border-slate-700 dark:bg-black dark:text-yellow-50"
+>
+	<h2 id="download-curriculum" class="text-base font-semibold">Download this curriculum</h2>
+	<div class="mt-4 flex flex-col gap-3 sm:flex-row">
+		{
+			downloadLinks.map((link) => (
+				<a href={link.href} download={link.filename} class={linkClass} aria-label={link.ariaLabel}>
+					<Icon name={link.icon} class="h-5 w-5" aria-hidden="true" /> {link.format}
+				</a>
+			))
+		}
+	</div>
+</section>

--- a/src/lib/curriculum/data.ts
+++ b/src/lib/curriculum/data.ts
@@ -1,0 +1,307 @@
+import { SITE } from '~/config';
+import contactInfoData from '~/assets/curriculum/contactInfo.json';
+import coursesData from '~/assets/curriculum/courses.json';
+import educationData from '~/assets/curriculum/education.json';
+import languagesData from '~/assets/curriculum/languages.json';
+import techStackData from '~/assets/curriculum/techStack.json';
+import workExperienceData from '~/assets/curriculum/workExperience.json';
+
+export const curriculumLocales = ['en-us', 'pt-br'] as const;
+
+export type CurriculumLocale = (typeof curriculumLocales)[number];
+
+export type CurriculumLink = {
+	label: string;
+	url: string;
+};
+
+export type CurriculumProfile = {
+	name: string;
+	headline: string;
+	location?: string;
+	email?: string;
+	links: CurriculumLink[];
+	summary: string;
+};
+
+export type CurriculumExperience = {
+	company: string;
+	role: string;
+	location?: string;
+	period: string;
+	summary?: string;
+	bullets: string[];
+	technologies: string[];
+};
+
+export type CurriculumProject = {
+	name: string;
+	description: string;
+	company?: string;
+	technologies: string[];
+	url?: string;
+};
+
+export type CurriculumEducation = {
+	title: string;
+	place: string;
+	time: string;
+	description?: string;
+};
+
+export type CurriculumCourse = CurriculumEducation & {
+	credentialID?: string;
+};
+
+export type CurriculumLanguage = {
+	title: string;
+	levelName: string;
+};
+
+type SourceTechStackGroup = {
+	category: string;
+	items: string[];
+};
+
+type SourceSelectedProject = {
+	title: string;
+	description: string;
+	company?: string;
+};
+
+type SourceExperience = {
+	title: string;
+	company: string;
+	period: string;
+	location: string;
+	area?: string;
+	summary?: string;
+	highlights?: string[];
+	selectedProjects?: SourceSelectedProject[];
+	tech: string[];
+};
+
+type SourceEducation = {
+	title: string;
+	place: string;
+	time: string;
+	description?: string;
+};
+
+type SourceCourse = SourceEducation & {
+	credentialID?: string;
+};
+
+type SourceLanguage = {
+	title: string;
+	levelName: string;
+};
+
+export type Curriculum = {
+	locale: CurriculumLocale;
+	labels: {
+		title: string;
+		subject: string;
+		contact: {
+			name: string;
+			title: string;
+			location: string;
+			email: string;
+			website: string;
+		};
+		sections: {
+			summary: string;
+			experience: string;
+			projects: string;
+			skills: string;
+			education: string;
+			courses: string;
+			languages: string;
+			links: string;
+		};
+		technologies: string;
+		link: string;
+	};
+	filename: string;
+	profile: CurriculumProfile;
+	experience: CurriculumExperience[];
+	projects: CurriculumProject[];
+	education: CurriculumEducation[];
+	courses: CurriculumCourse[];
+	skills: Record<string, string[]>;
+	languages: CurriculumLanguage[];
+};
+
+const techStack = techStackData as SourceTechStackGroup[];
+const experience = workExperienceData as SourceExperience[];
+const education = educationData as SourceEducation[];
+const courses = coursesData as SourceCourse[];
+const languages = languagesData as SourceLanguage[];
+
+const emailHref = contactInfoData.find((item) => item.href.startsWith('mailto:'))?.href;
+const githubHref = contactInfoData.find((item) => item.href.includes('github.com'))?.href;
+const linkedinHref = contactInfoData.find((item) => item.href.includes('linkedin.com'))?.href;
+
+const profile = {
+	name: 'Thomas B. Verderesi',
+	title: 'Fullstack Software Engineer',
+	location: 'Curitiba, Parana, Brazil',
+	url: SITE.origin,
+	email: emailHref?.replace('mailto:', ''),
+	github: githubHref,
+	linkedin: linkedinHref,
+	summary:
+		'Full-stack software engineer with experience designing, building, and modernizing complex web systems across backend, frontend, architecture, reporting, internal platforms, and data-heavy applications. I work with a senior engineering mindset: connecting implementation with product goals, clarifying trade-offs, improving service boundaries, reducing architectural debt, and building systems that are reliable, maintainable, and easier to evolve.',
+};
+
+const localizedSummary = {
+	'en-us':
+		profile.summary ||
+		'Software engineer focused on web systems, technical product work, and AI tools for humans. I build web systems, refactor complex codebases, and turn product ideas into working software.',
+	'pt-br':
+		'Engenheiro de software focado em sistemas web, trabalho técnico de produto e ferramentas de IA para pessoas. Construo sistemas web, refatoro bases de código complexas e transformo ideias de produto em software funcional.',
+} satisfies Record<CurriculumLocale, string>;
+
+const labels = {
+	'en-us': {
+		title: 'Thomas Verderesi - Curriculum - EN-US',
+		subject: 'Software Engineer Curriculum',
+		contact: {
+			name: 'Name',
+			title: 'Title',
+			location: 'Location',
+			email: 'Email',
+			website: 'Website',
+		},
+		sections: {
+			summary: 'Professional Summary',
+			experience: 'Experience',
+			projects: 'Projects',
+			skills: 'Skills',
+			education: 'Education',
+			courses: 'Courses and Certifications',
+			languages: 'Languages',
+			links: 'Links',
+		},
+		technologies: 'Technologies',
+		link: 'Link',
+	},
+	'pt-br': {
+		title: 'Thomas Verderesi - Currículo - PT-BR',
+		subject: 'Currículo de Engenheiro de Software',
+		contact: {
+			name: 'Nome',
+			title: 'Título',
+			location: 'Localização',
+			email: 'Email',
+			website: 'Site',
+		},
+		sections: {
+			summary: 'Resumo Profissional',
+			experience: 'Experiência',
+			projects: 'Projetos',
+			skills: 'Competências',
+			education: 'Educação',
+			courses: 'Cursos e Certificações',
+			languages: 'Idiomas',
+			links: 'Links',
+		},
+		technologies: 'Tecnologias',
+		link: 'Link',
+	},
+} satisfies Record<CurriculumLocale, Curriculum['labels']>;
+
+const filenames = {
+	'en-us': 'thomas-verderesi-curriculum-en-us.pdf',
+	'pt-br': 'thomas-verderesi-curriculo-pt-br.pdf',
+} satisfies Record<CurriculumLocale, string>;
+
+const skillCategoryTranslations: Record<string, string> = {
+	Languages: 'Linguagens',
+	Frontend: 'Frontend',
+	Backend: 'Backend',
+	'Databases & Search': 'Bancos de Dados e Busca',
+	Testing: 'Testes',
+	'Infrastructure & Tooling': 'Infraestrutura e Ferramentas',
+};
+
+const languageTranslations: Record<string, string> = {
+	Portuguese: 'Português',
+	English: 'Inglês',
+	French: 'Francês',
+};
+
+const headlineByLocale = {
+	'en-us': profile.title,
+	'pt-br': 'Engenheiro de Software Full-stack',
+} satisfies Record<CurriculumLocale, string>;
+
+const normalizeUrl = (href?: string) => {
+	if (!href) return undefined;
+	return href.startsWith('mailto:') ? href.replace('mailto:', '') : href;
+};
+
+const profileLinks = [
+	{ label: 'LinkedIn', url: profile.linkedin },
+	{ label: 'GitHub', url: profile.github },
+	{ label: 'Website', url: profile.url },
+]
+	.map(({ label, url }) => (url ? { label, url: normalizeUrl(url) ?? url } : undefined))
+	.filter((link): link is CurriculumLink => Boolean(link?.url));
+
+const buildKeywords = () =>
+	Array.from(
+		new Set([
+			'Software Engineer',
+			'Web Systems',
+			'Technical Product Work',
+			'AI Tools for Humans',
+			'Astro',
+			...techStack.flatMap((group) => group.items),
+			...experience.flatMap((item) => item.tech),
+		])
+	);
+
+export const curriculumKeywords = buildKeywords();
+
+export const isCurriculumLocale = (value: string | undefined): value is CurriculumLocale => curriculumLocales.includes(value as CurriculumLocale);
+
+export const getCurriculum = (locale: CurriculumLocale): Curriculum => ({
+	locale,
+	labels: labels[locale],
+	filename: filenames[locale],
+	profile: {
+		name: profile.name,
+		headline: headlineByLocale[locale],
+		location: profile.location,
+		email: profile.email,
+		links: profileLinks,
+		summary: localizedSummary[locale],
+	},
+	experience: experience.map((item) => ({
+		company: item.company,
+		role: item.title,
+		location: item.location,
+		period: item.period,
+		summary: item.summary,
+		bullets: item.highlights ?? [],
+		technologies: item.tech,
+	})),
+	projects: experience.flatMap((item) =>
+		(item.selectedProjects ?? []).map((project) => ({
+			name: project.title,
+			description: project.description,
+			company: item.company,
+			technologies: item.tech,
+		}))
+	),
+	education,
+	courses,
+	skills: Object.fromEntries(
+		techStack.map((group) => [locale === 'pt-br' ? skillCategoryTranslations[group.category] || group.category : group.category, group.items])
+	),
+	languages: languages.map((language) => ({
+		title: locale === 'pt-br' ? languageTranslations[language.title] || language.title : language.title,
+		levelName: language.levelName.trim(),
+	})),
+});

--- a/src/lib/curriculum/pdf.ts
+++ b/src/lib/curriculum/pdf.ts
@@ -1,0 +1,216 @@
+import PDFDocument from 'pdfkit';
+import type { Curriculum } from './data';
+import { curriculumKeywords } from './data';
+
+const margins = {
+	top: 52,
+	bottom: 52,
+	left: 54,
+	right: 54,
+};
+
+const colors = {
+	text: '#111111',
+	muted: '#404040',
+	link: '#0645ad',
+	rule: '#111111',
+};
+
+const pageWidth = 612;
+const contentWidth = pageWidth - margins.left - margins.right;
+
+type PdfDoc = InstanceType<typeof PDFDocument>;
+
+const lineGap = 3;
+
+const ensureSpace = (doc: PdfDoc, height = 90) => {
+	if (doc.y + height > doc.page.height - margins.bottom) {
+		doc.addPage();
+	}
+};
+
+const text = (doc: PdfDoc, value: string, options: PDFKit.Mixins.TextOptions = {}) => {
+	doc
+		.fillColor(colors.text)
+		.font('Helvetica')
+		.fontSize(10)
+		.text(value, {
+			width: contentWidth,
+			lineGap,
+			...options,
+		});
+};
+
+const section = (doc: PdfDoc, title: string) => {
+	ensureSpace(doc, 72);
+	doc.moveDown(0.9);
+	doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(12).text(title.toUpperCase(), { width: contentWidth, lineGap: 2 });
+	doc
+		.moveTo(margins.left, doc.y + 2)
+		.lineTo(margins.left + contentWidth, doc.y + 2)
+		.strokeColor(colors.rule)
+		.lineWidth(1)
+		.stroke();
+	doc.moveDown(0.6);
+};
+
+const listItem = (doc: PdfDoc, value: string) => {
+	ensureSpace(doc, 34);
+	text(doc, `- ${value}`, { indent: 10 });
+};
+
+const labelValue = (doc: PdfDoc, label: string, value?: string) => {
+	if (!value) return;
+	ensureSpace(doc, 24);
+	doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(10).text(`${label}: `, { continued: true, lineGap });
+	doc.fillColor(colors.text).font('Helvetica').fontSize(10).text(value, { width: contentWidth, lineGap });
+};
+
+const linkLine = (doc: PdfDoc, label: string, url: string) => {
+	ensureSpace(doc, 24);
+	doc.fillColor(colors.link).font('Helvetica').fontSize(10).text(`${label}: ${url}`, {
+		width: contentWidth,
+		lineGap,
+		link: url,
+		underline: true,
+	});
+};
+
+const renderExperience = (doc: PdfDoc, curriculum: Curriculum) => {
+	section(doc, curriculum.labels.sections.experience);
+
+	curriculum.experience.forEach((item) => {
+		ensureSpace(doc, 110);
+		doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(11).text(`${item.company} - ${item.role}`, { width: contentWidth, lineGap });
+		doc
+			.fillColor(colors.muted)
+			.font('Helvetica')
+			.fontSize(9.5)
+			.text([item.location, item.period].filter(Boolean).join(' | '), { width: contentWidth, lineGap });
+
+		if (item.summary) {
+			text(doc, item.summary);
+		}
+
+		item.bullets.forEach((bullet) => listItem(doc, bullet));
+
+		if (item.technologies.length > 0) {
+			text(doc, `${curriculum.labels.technologies}: ${item.technologies.join(', ')}`);
+		}
+
+		doc.moveDown(0.6);
+	});
+};
+
+const renderProjects = (doc: PdfDoc, curriculum: Curriculum) => {
+	if (curriculum.projects.length === 0) return;
+
+	section(doc, curriculum.labels.sections.projects);
+
+	curriculum.projects.forEach((project) => {
+		ensureSpace(doc, 82);
+		doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(11).text(project.name, { width: contentWidth, lineGap });
+		if (project.company) {
+			doc.fillColor(colors.muted).font('Helvetica').fontSize(9.5).text(project.company, { width: contentWidth, lineGap });
+		}
+		text(doc, project.description);
+		if (project.technologies.length > 0) {
+			text(doc, `${curriculum.labels.technologies}: ${project.technologies.join(', ')}`);
+		}
+		if (project.url) {
+			linkLine(doc, curriculum.labels.link, project.url);
+		}
+		doc.moveDown(0.5);
+	});
+};
+
+const renderSkills = (doc: PdfDoc, curriculum: Curriculum) => {
+	section(doc, curriculum.labels.sections.skills);
+	Object.entries(curriculum.skills).forEach(([category, items]) => {
+		if (items.length === 0) return;
+		text(doc, `${category}: ${items.join(', ')}`);
+	});
+};
+
+const renderEducation = (doc: PdfDoc, curriculum: Curriculum) => {
+	if (curriculum.education.length === 0) return;
+
+	section(doc, curriculum.labels.sections.education);
+	curriculum.education.forEach((item) => {
+		ensureSpace(doc, 50);
+		doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(10.5).text(item.title, { width: contentWidth, lineGap });
+		text(doc, `${item.place} | ${item.time}`);
+		if (item.description) text(doc, item.description);
+		doc.moveDown(0.4);
+	});
+};
+
+const renderCourses = (doc: PdfDoc, curriculum: Curriculum) => {
+	if (curriculum.courses.length === 0) return;
+
+	section(doc, curriculum.labels.sections.courses);
+	curriculum.courses.forEach((item) => {
+		ensureSpace(doc, 56);
+		doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(10.5).text(item.title, { width: contentWidth, lineGap });
+		text(doc, `${item.place} | ${item.time}`);
+		if (item.credentialID) text(doc, `Credential ID: ${item.credentialID}`);
+		if (item.description) text(doc, item.description);
+		doc.moveDown(0.4);
+	});
+};
+
+const renderLanguages = (doc: PdfDoc, curriculum: Curriculum) => {
+	if (curriculum.languages.length === 0) return;
+
+	section(doc, curriculum.labels.sections.languages);
+	curriculum.languages.forEach((language) => {
+		text(doc, `${language.title}: ${language.levelName}`);
+	});
+};
+
+export const generateCurriculumPdf = (curriculum: Curriculum) =>
+	new Promise<Buffer>((resolve, reject) => {
+		const doc = new PDFDocument({
+			size: 'LETTER',
+			margins,
+			compress: false,
+			info: {
+				Title: curriculum.labels.title,
+				Author: 'Thomas Verderesi',
+				Subject: curriculum.labels.subject,
+				Keywords: curriculumKeywords.join(', '),
+				Creator: 'Astro + PDFKit',
+			},
+		});
+
+		const chunks: Buffer[] = [];
+
+		doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+		doc.on('end', () => resolve(Buffer.concat(chunks)));
+		doc.on('error', reject);
+
+		doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(21).text(curriculum.profile.name, { width: contentWidth, lineGap: 2 });
+		doc.fillColor(colors.text).font('Helvetica-Bold').fontSize(12).text(curriculum.profile.headline, { width: contentWidth, lineGap: 2 });
+		doc.moveDown(0.8);
+
+		labelValue(doc, curriculum.labels.contact.name, curriculum.profile.name);
+		labelValue(doc, curriculum.labels.contact.title, curriculum.profile.headline);
+		labelValue(doc, curriculum.labels.contact.location, curriculum.profile.location);
+		labelValue(doc, curriculum.labels.contact.email, curriculum.profile.email);
+		labelValue(doc, curriculum.labels.contact.website, curriculum.profile.links.find((link) => link.label === 'Website')?.url);
+
+		section(doc, curriculum.labels.sections.links);
+		curriculum.profile.links.forEach((link) => linkLine(doc, link.label, link.url));
+
+		section(doc, curriculum.labels.sections.summary);
+		text(doc, curriculum.profile.summary);
+
+		renderExperience(doc, curriculum);
+		renderProjects(doc, curriculum);
+		renderSkills(doc, curriculum);
+		renderEducation(doc, curriculum);
+		renderCourses(doc, curriculum);
+		renderLanguages(doc, curriculum);
+
+		doc.end();
+	});

--- a/src/pages/api/curriculum/[locale].pdf.ts
+++ b/src/pages/api/curriculum/[locale].pdf.ts
@@ -1,0 +1,31 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { curriculumLocales, getCurriculum, isCurriculumLocale } from '~/lib/curriculum/data';
+import { generateCurriculumPdf } from '~/lib/curriculum/pdf';
+
+export const prerender = true;
+
+export const getStaticPaths: GetStaticPaths = () => curriculumLocales.map((locale) => ({ params: { locale } }));
+
+export const GET: APIRoute = async ({ params }) => {
+	const locale = params.locale?.replace(/\.pdf$/, '');
+
+	if (!isCurriculumLocale(locale)) {
+		return new Response('Unsupported curriculum locale.', { status: 404 });
+	}
+
+	try {
+		const curriculum = getCurriculum(locale);
+		const pdf = await generateCurriculumPdf(curriculum);
+
+		return new Response(new Uint8Array(pdf), {
+			headers: {
+				'Content-Type': 'application/pdf',
+				'Content-Disposition': `attachment; filename="${curriculum.filename}"`,
+				'Cache-Control': 'public, max-age=3600',
+			},
+		});
+	} catch (error) {
+		console.error(`Failed to generate ${locale} curriculum PDF`, error);
+		return new Response('Failed to generate curriculum PDF.', { status: 500 });
+	}
+};

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,32 @@
           "value": "public, max-age=31536000, immutable"
         }
       ]
+    },
+    {
+      "source": "/api/curriculum/en-us.pdf",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/pdf"
+        },
+        {
+          "key": "Content-Disposition",
+          "value": "attachment; filename=\"thomas-verderesi-curriculum-en-us.pdf\""
+        }
+      ]
+    },
+    {
+      "source": "/api/curriculum/pt-br.pdf",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/pdf"
+        },
+        {
+          "key": "Content-Disposition",
+          "value": "attachment; filename=\"thomas-verderesi-curriculo-pt-br.pdf\""
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds build-time generated, ATS-friendly curriculum PDFs for English and Brazilian Portuguese using the existing structured curriculum JSON data.

## Changes

- Adds a prerendered Astro PDF route at `/api/curriculum/[locale].pdf.ts` for `en-us` and `pt-br`.
- Adds a typed curriculum normalization layer and PDFKit renderer with real selectable text, plain section headings, visible links, and PDF metadata.
- Updates the curriculum download component and download links to use the generated local PDF URLs.
- Adds Vercel and Netlify headers so static PDF files are served as attachments with clear filenames.

## Validation

- `pnpm typecheck` passed with existing project hints only.
- `ASTRO_TELEMETRY_DISABLED=1 pnpm build` passed.
- Verified the build emits:
  - `dist/api/curriculum/en-us.pdf`
  - `dist/api/curriculum/pt-br.pdf`
- Verified both outputs are valid 4-page PDF files.