### PR TITLE
Align Node version between CI and hosting to fix failing PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "workbox-window": "^7.3.0"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
### Motivation
- The PR build was failing due to a Node runtime mismatch between the repository (declared `>=24.0.0`) and typical CI/hosting environments running Node 22, causing install/build inconsistencies. 
- Aligning the declared engine and CI runtime prevents environment mismatches that block dependency install and preview deployments.

### Description
- Updated `package.json` `engines.node` from `>=24.0.0` to `>=22.0.0`.
- Updated `.github/workflows/ci.yml` `Setup Node` step to use `node-version: 22` instead of `24`.
- These changes ensure CI and hosted preview environments run the same major Node runtime.

### Testing
- Ran `pnpm install --frozen-lockfile` and it completed successfully.
- Ran `pnpm typecheck` and it completed with no errors (only hints/warnings reported by the checker).
- Ran `pnpm build` and the static site build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42c31f0c0832493ac148468265039)